### PR TITLE
Fixed Discord links in bug-and-exploit-reward-system.md

### DIFF
--- a/docs/bug-and-exploit-reward-system.md
+++ b/docs/bug-and-exploit-reward-system.md
@@ -8,14 +8,14 @@ If you're unsure whether a particular method of money-making is excessively prof
 
 ### How to Report a Bug or Game-Breaking Mechanic
 
-1. Navigate to our [\[Private Support Tickets\]](https://discord.gg/D3syEwEPrV) channel in Discord.
+1. Navigate to our [\[Private Support Tickets\]](https://discord.gg/j52jh94zKx) channel in Discord.
 2. Provide a **clear description** of the bug or game-breaking mechanic. What is it, and what does it affect?
 3. Detail the **steps to reproduce** the bug or mechanic. This will help us identify and fix the issue more quickly.
 4. If possible, include **screenshots or videos**.
 
 ### How to Report an Exploit
 
-Due to the potentially harmful nature of exploits, these should be reported directly to a server administrator or owner. You can contact an admin through [\[Private Support Tickets\]](https://discord.gg/D3syEwEPrV).
+Due to the potentially harmful nature of exploits, these should be reported directly to a server administrator or owner. You can contact an admin through [\[Private Support Tickets\]](https://discord.gg/4aummv3W24).
 
 ### Incentives
 


### PR DESCRIPTION
I made 2 new invite links 
one for #staff-support-tickets and one for #admin-support

They Should be set to never expire